### PR TITLE
Ensure it's only run once

### DIFF
--- a/fixture/child-compiler-plugin.js
+++ b/fixture/child-compiler-plugin.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = class ChildCompilerPlugin {
+	apply(compiler) {
+		compiler.hooks.make.tapAsync('ChildCompilerPlugin', (compilation, callback) => {
+			const childCompiler = compilation.createChildCompiler('ChildCompilerPlugin');
+			childCompiler.runAsChild(callback);
+		});
+	}
+};

--- a/fixture/webpack.config.js
+++ b/fixture/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict';
 const AddAssetPlugin = require('..');
+const ChildCompilerPlugin = require('./child-compiler-plugin');
 
 module.exports = {
 	output: {
@@ -9,6 +10,7 @@ module.exports = {
 	plugins: [
 		new AddAssetPlugin('rainbow.js', 'console.log("🌈")'),
 		new AddAssetPlugin('cake.js', () => 'console.log("🎂")'),
-		new AddAssetPlugin('cat.js', () => Promise.resolve('console.log("🐈")'))
+		new AddAssetPlugin('cat.js', () => Promise.resolve('console.log("🐈")')),
+		new ChildCompilerPlugin()
 	]
 };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = class AddAssetPlugin {
 	}
 
 	apply(compiler) {
-		compiler.hooks.compilation.tap('AddAssetPlugin', compilation => {
+		compiler.hooks.thisCompilation.tap('AddAssetPlugin', compilation => {
 			compilation.hooks.processAssets.tapPromise(tapOptions, async () => {
 				let source;
 				if (typeof this.source === 'string') {

--- a/test.js
+++ b/test.js
@@ -9,7 +9,8 @@ test('main', async t => {
 	const config = require('./fixture/webpack.config');
 	const cwd = tempy.directory();
 	config.output.path = cwd;
-	await pify(webpack)(config);
+	const stats = await pify(webpack)(config);
+	t.false(stats.hasErrors());
 	t.true(fs.readFileSync(path.join(cwd, 'unicorn.js'), 'utf8').includes('🦄'));
 	t.true(fs.readFileSync(path.join(cwd, 'rainbow.js'), 'utf8').includes('🌈'));
 	t.true(fs.readFileSync(path.join(cwd, 'cake.js'), 'utf8').includes('🎂'));


### PR DESCRIPTION
Hi. I noticed that if you have other plugins in your config that spawn child compilations (e.g. HtmlWebpackPlugin, MiniCssExtractPlugin, WorkboxWebpackPlugin), AddAssetPlugin will run more than once. It's because child compilations inherit the plugins of the parent compilation.

In Webpack 5 it will result in a **"Conflict: Multiple assets emit different content to the same filename"** compilation error. You can see this by checking out the first commit of this PR and running the tests; both `cake.js` and `cat.js` produce this error when ChildCompilerPlugin is present in the config.

I think a good way to protect against this is to use `compiler.hooks.thisCompilation` instead of `compiler.hooks.compilation`, which is an approach I've seen used by other plugins (e.g. https://github.com/webpack-contrib/copy-webpack-plugin/pull/507). It will ensure that AddAssetPlugin only runs once (in the parent compilation). If you check out the second commit and run the tests, you'll see that the error is gone.