### PR TITLE
Mark webpack as optional peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
 	},
 	"peerDependencies": {
 		"webpack": ">=5"
+	},
+	"peerDependenciesMeta": {
+		"webpack": {
+			"optional": true
+		}
 	}
 }


### PR DESCRIPTION
This plugin also works with [rspack](https://github.com/web-infra-dev/rspack), so I think it's prudent to mark it as a optional peer to prevent unnecessary installations of webpack.